### PR TITLE
Update checkTO.

### DIFF
--- a/R/checkTO.R
+++ b/R/checkTO.R
@@ -77,7 +77,16 @@ checkTO <- function(traj,traj2){
     
   }
   
-  pairs$t.min <- as.POSIXct(pairs$t.min)
-  pairs$t.max <- as.POSIXct(pairs$t.max)
+  if (class(pairs$t.min) == "POSIXct") {
+    break
+  } else {
+    pairs$t.min <- as.POSIXct(pairs$t.min)
+  }
+  if (class(pairs$t.max) == "POSIXct") {
+    break
+  } else {
+    pairs$t.max <- as.POSIXct(pairs$t.max)
+  }
+  
   return(pairs)
 }

--- a/R/checkTO.R
+++ b/R/checkTO.R
@@ -77,15 +77,18 @@ checkTO <- function(traj,traj2){
     
   }
   
-  if (class(pairs$t.min) == "POSIXct") {
-    break
+  #origin of numerical dates
+  origin = "1970-01-01"
+  
+  if (is.numeric.POSIXt(pairs$t.min)) {
+    #do nothing
   } else {
-    pairs$t.min <- as.POSIXct(pairs$t.min)
+    pairs$t.min <- as.POSIXct(pairs$t.min, origin = origin)
   }
-  if (class(pairs$t.max) == "POSIXct") {
-    break
+  if (is.numeric.POSIXt(pairs$t.max)) {
+    #do nothing
   } else {
-    pairs$t.max <- as.POSIXct(pairs$t.max)
+    pairs$t.max <- as.POSIXct(pairs$t.max, origin = origin)
   }
   
   return(pairs)


### PR DESCRIPTION
as.POSIXct was failing to convert pairs$t.min and pars$t.max because they were numerical. If you pass in the origin of computer date time (1970-01-01), it converts as expected and there are no errors with the description examples. 